### PR TITLE
init: setup boot properties

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,0 +1,14 @@
+_has_qemu := $(filter qemu=%,$(BOARD_KERNEL_CMDLINE))
+ADDITIONAL_DEFAULT_PROPERTIES += \
+  $(foreach p,$(BOARD_KERNEL_CMDLINE), \
+    $(eval _key := $(word 1,$(subst =,$(space),$(p)))) \
+    $(eval _value := $(word 2,$(subst =,$(space),$(p)))) \
+    $(if $(filter x,$(_key)x $(_value)x),, \
+      $(if $(_has_qemu),ro.kernel.$(_key)=$(_value)) \
+      $(if $(filter androidboot.%,$(_key)), \
+        $(subst androidboot.,ro.boot.,$(_key))=$(_value) \
+      ) \
+    ) \
+  )
+_has_qemu :=
+

--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -1,20 +1,17 @@
 BOARD_IS_CONTAINER := true
 
-BOARD_DOCKER_ENVVARS := \
-  INIT_KERNEL_CMDLINE \
+BOARD_DOCKER_VOLUMES := \
+  /data \
   $(empty)
+
+BOARD_DOCKER_ENTRYPOINT := "/init"
+
 # See external/qemu/android/android-emu/android/main-kernel-parameters.cpp,
 # function emulator_getKernelParameters for more.
-BOARD_DOCKER_ENV_INIT_KERNEL_CMDLINE := \
+BOARD_KERNEL_CMDLINE := \
   qemu=1 \
   androidboot.hardware=ranchu \
   android.bootanim=0 \
   qemu.gles=1 \
   qemu.opengles.version=65536 \
   $(empty)
-
-BOARD_DOCKER_VOLUMES := \
-  /data \
-  $(empty)
-
-BOARD_DOCKER_ENTRYPOINT := "/init"


### PR DESCRIPTION
Don't rely on Docker ENV, because any env vars will be cleared before
init execution in next Android release, then we'll have to invent
another way to inject kernel command line parameters. Binding mounting
/proc/cmdline is also not an option, because it's forbidden in Docker to
do so. Therefore, the only valid option we have here is to translate
referenced parameters to readonly default properties.